### PR TITLE
chore: verify cflite_pr.yml workflow fires

### DIFF
--- a/tests/Jellyfin.Plugin.TwoFactorAuth.Fuzz/Program.cs
+++ b/tests/Jellyfin.Plugin.TwoFactorAuth.Fuzz/Program.cs
@@ -22,6 +22,8 @@ namespace Jellyfin.Plugin.TwoFactorAuth.Fuzz;
 /// ClusterFuzzLite handles all of that automatically inside the
 /// `.clusterfuzzlite/Dockerfile` build.
 /// </summary>
+// Marker change to verify cflite_pr.yml fires on PRs touching this file.
+// Safe to remove after the first successful ClusterFuzzLite PR run.
 internal static class Program
 {
     public static void Main(string[] args)


### PR DESCRIPTION
## Purpose
Verification PR to confirm `.github/workflows/cflite_pr.yml` (added in v2.4.3) actually triggers when a PR touches `tests/Jellyfin.Plugin.TwoFactorAuth.Fuzz/`. Workflow only fires on `pull_request` events, so we can't validate it from a direct push.

## What's in this PR
One-line comment added to `Program.cs` in the fuzz harness. No behavior change.

## Expected
- `ClusterFuzzLite PR fuzzing / PR (address)` job runs
- Fuzzers build inside the OSS-Fuzz `base-builder-csharp` image
- 5-minute fuzz against `BypassEvaluator.PickRealClientIp`
- Job concludes success (no crashes found)

If green, this PR proves the fuzz pipeline works end-to-end. We can then add the Scorecard / fuzz badge to the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)