### PR TITLE
fix(#50): login.html OTP input now accepts 8-digit email codes

### DIFF
--- a/src/Jellyfin.Plugin.TwoFactorAuth/Pages/login.html
+++ b/src/Jellyfin.Plugin.TwoFactorAuth/Pages/login.html
@@ -118,7 +118,7 @@
         <input type="password" id="password" autocomplete="current-password" />
 
         <label id="codeLabel"><span data-i18n-key="tfa.login.code_label_main">6-digit Code</span> <span style="color:#555;text-transform:none;" data-i18n-key="tfa.login.code_label_hint">(leave blank if 2FA isn't set up)</span></label>
-        <input type="text" id="code" class="code-input" maxlength="6" inputmode="numeric" placeholder="000000" autocomplete="one-time-code" />
+        <input type="text" id="code" class="code-input" maxlength="8" inputmode="numeric" placeholder="000000" autocomplete="one-time-code" />
 
         <a class="toggle-link" id="toggleRecovery" data-i18n-key="tfa.challenge.recovery_label">Use a recovery code instead</a>
 
@@ -195,7 +195,7 @@
                 toggle.textContent = _tr('tfa.login.toggle_use_code', 'Use 6-digit code instead');
             } else {
                 input.classList.remove('recovery');
-                input.setAttribute('maxlength', '6');
+                input.setAttribute('maxlength', '8');
                 input.setAttribute('placeholder', '000000');
                 input.setAttribute('autocomplete', 'one-time-code');
                 label.innerHTML = _tr('tfa.login.code_label_main', '6-digit Code') + ' <span style="color:#555;text-transform:none;">' + _tr('tfa.login.code_label_hint', '(leave blank if 2FA isn\'t set up)') + '</span>';
@@ -215,7 +215,7 @@
                 // Allow letters/digits/dash, uppercase
                 e.target.value = e.target.value.toUpperCase().replace(/[^A-Z0-9-]/g, '').slice(0, 14);
             } else {
-                e.target.value = e.target.value.replace(/\D/g, '').slice(0, 6);
+                e.target.value = e.target.value.replace(/\D/g, '').slice(0, 8);
             }
         });
 


### PR DESCRIPTION
## Problem

The `EmailOtpService` generates **8-digit** codes (v2.5.5 security hardening), and `challenge.html` already switches `maxlength` dynamically per method. However, `login.html` still had `maxlength="6"` hardcoded on the code input field, preventing users from entering 8-digit email OTP codes.

## Changes

- `maxlength` attribute: `6` → `8`
- Input sanitizer `slice`: `0, 6` → `0, 8`
- `setRecoveryMode` off-branch `maxlength`: `6` → `8`

## Context

The `EmailOtpService.cs` (line 62) generates codes with:
```csharp
var code = RandomNumberGenerator.GetInt32(10_000_000, 100_000_000).ToString("D8", ...);
```

The `challenge.html` already has partial fixes for this (lines 355-366), but `login.html` was missed.

Fixes #50