### PR TITLE
feat(#104): admin endpoint to re-arm MustSetPassword for no-SMTP local password recovery

### DIFF
--- a/src/Jellyfin.Plugin.TwoFactorAuth/Api/TwoFactorAuthController.cs
+++ b/src/Jellyfin.Plugin.TwoFactorAuth/Api/TwoFactorAuthController.cs
@@ -2682,6 +2682,43 @@ public class TwoFactorAuthController : ControllerBase
     }
 
     // -------------------------------------------------------------------------
+    // 12a. POST /TwoFactorAuth/Users/{id}/RequirePasswordSetup [Authorize(Policy = "RequiresElevation")]
+    // -------------------------------------------------------------------------
+    // (#104) Re-arm MustSetPassword so an admin can let a returning user who
+    // forgot their Jellyfin-local password set a new one on next OIDC login,
+    // without SMTP. The existing no-old-password gate in SetOnboardingPassword
+    // (the MustSetPassword check) is unchanged; this only sets the flag the
+    // same way new-user OIDC provision already does. The old password stays
+    // valid until the user completes setup, so no one is locked out.
+
+    [HttpPost("Users/{id}/RequirePasswordSetup")]
+    [Authorize(Policy = "RequiresElevation")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<ActionResult> RequirePasswordSetup([FromRoute] Guid id)
+    {
+        // SECURITY (#104): require step-up. Re-arming MustSetPassword on behalf
+        // of another user is a privileged action — same classification as
+        // ToggleUser / ResetOtherUser2fa.
+        var guard = StepUpGuard(StepUpAction.ResetOtherUser2fa);
+        if (guard is not null) return guard;
+
+        var ju = _userManager.GetUserById(id);
+        await _store.MutateAsync(id, ud => ud.MustSetPassword = true).ConfigureAwait(false);
+
+        await _store.AddAuditEntryAsync(new AuditEntry
+        {
+            Timestamp = DateTime.UtcNow,
+            UserId = id,
+            Username = ju?.Username ?? id.ToString(),
+            RemoteIp = HttpContext.Connection.RemoteIpAddress?.ToString() ?? string.Empty,
+            Result = AuditResult.ConfigChanged,
+            Method = "admin_require_pw_setup",
+        }).ConfigureAwait(false);
+
+        return Ok();
+    }
+
+    // -------------------------------------------------------------------------
     // 13. GET /TwoFactorAuth/AuditLog [Authorize(Policy = "RequiresElevation")]
     // -------------------------------------------------------------------------
 

--- a/src/Jellyfin.Plugin.TwoFactorAuth/Pages/admin-script.js
+++ b/src/Jellyfin.Plugin.TwoFactorAuth/Pages/admin-script.js
@@ -650,7 +650,8 @@
                               '<button class="tfa-btn tfa-btn-primary tfa-toggle" data-id="' + uid + '" data-next="' + !totp + '">' + escapeHtml(totp ? tDisable : tEnable) + '</button> ' +
                               '<button class="tfa-btn tfa-btn-danger tfa-force-logout" data-id="' + uid + '">' + escapeHtml(tForceLogout) + '</button> ' +
                               '<button class="tfa-btn tfa-revoke-all" data-id="' + uid + '">' + escapeHtml(tRevokeAll) + '</button> ' +
-                              '<button class="tfa-btn tfa-export-user" data-id="' + uid + '">' + escapeHtml(tExport) + '</button>' +
+                              '<button class="tfa-btn tfa-export-user" data-id="' + uid + '">' + escapeHtml(tExport) + '</button> ' +
+                              '<button class="tfa-btn tfa-require-pw-setup" data-id="' + uid + '">' + escapeHtml(_tr('tfa.admin.users.require_pw_setup', 'Require password setup')) + '</button>' +
                             '</td>' +
                             '</tr>' +
                             // Hidden details row — populated lazily on first toggle
@@ -693,6 +694,16 @@
                     body.querySelectorAll('.tfa-export-user').forEach(function(b) {
                         b.addEventListener('click', function() {
                             downloadGet('TwoFactorAuth/Users/' + encodeURIComponent(b.dataset.id) + '/Export', '2fa-export-' + b.dataset.id + '.json');
+                        });
+                    });
+                    // (#104) Re-arm MustSetPassword so the user is routed to
+                    // /TwoFactorAuth/SetPassword on next OIDC login.
+                    body.querySelectorAll('.tfa-require-pw-setup').forEach(function(b) {
+                        b.addEventListener('click', function() {
+                            if (!confirm(_tr('tfa.admin.users.confirm_require_pw_setup', 'Flag this user to set a new local Jellyfin password on their next OIDC login? Their existing password remains valid until they complete setup.'))) return;
+                            apiPost('TwoFactorAuth/Users/' + b.dataset.id + '/RequirePasswordSetup').then(function() {
+                                alert(_tr('tfa.admin.users.require_pw_setup_done', 'Done. The user will be prompted to set a new password on their next sign-in.'));
+                            }).catch(function() { alert(_tr('tfa.admin.common.error', 'An error occurred. Check that step-up is satisfied.')); });
                         });
                     });
                     wireUsersRowExtras();


### PR DESCRIPTION
Thanks for the go-ahead on this one.

Closes #104.

**The gap:** A returning OIDC user who forgot their Jellyfin-local password has no no-SMTP path back. Jellyfin's built-in change-password requires the current (forgotten) password. The plugin's `SetOnboardingPassword` endpoint (`POST /TwoFactorAuth/SetPassword`) skips the old-password check, but it's hard-gated by `if (!data.MustSetPassword) return BadRequest(...)`. `MustSetPassword` is only written `true` in one place: the auto-create branch of `ResolveUserAsync` for new OIDC users with `ForcePasswordSetup` on. There is no way to re-arm it for an existing user, so the recovery dead end is complete when SMTP is absent.

**The fix:** `POST /TwoFactorAuth/Users/{id}/RequirePasswordSetup` sets `MustSetPassword = true` for the target user. The implementation mirrors `ToggleUser` (section 12 of the controller) exactly: `RequiresElevation` policy, `ResetOtherUser2fa` step-up guard, `MutateAsync` for an atomic write-through, and a `ConfigChanged` audit entry with `Method = "admin_require_pw_setup"`. After the admin flips the flag, the user's next OIDC login is routed to `/TwoFactorAuth/SetPassword` by the existing bridge logic in `SecurityController` (which already reads `MustSetPassword` for every login, not just new users), the existing gate at `SetOnboardingPassword:4734` is satisfied, and the flag self-clears at `:4758`. The old password keeps working until then, so no one is locked out. Nothing else is changed: the `MustSetPassword` guard, the rate limiter, the validator, and the bridge routing are all untouched.

The admin UI gets a "Require password setup" button in the Users table, wired the same way as the other per-user action buttons, with a confirmation dialog before firing.

**Build status:** `dotnet` is not installed in my local environment, so I could not build locally. The change is additive and follows the same patterns as existing endpoints, so I do not expect compilation issues, but please verify on your side.

Happy to adjust the endpoint name, route, or button label if you prefer a different shape.