### PR TITLE
ci: bump the pinned actions, with the codeql-action family in lockstep

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -10,7 +10,7 @@
 # accepts csharp from its GitHub Action wrapper. Until that day this
 # Dockerfile exists primarily for OpenSSF Scorecard's Fuzzing-check
 # scaffolding detection (which looks at file presence, not behavior).
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:b3bfcae9c08f56cfb052aa7e5cef00078c04aaad9fad58ee2c67e119e5415df8
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:8b4a73d83374b298a0a771eeec9a1d44ceff3416a678b7d7946303389d022aca
 
 # Stage the repo and the build script at the paths CFLite expects.
 COPY . $SRC/JellyfinSecurity

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup .NET 9
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
@@ -49,7 +49,7 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup .NET 9
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup .NET 9
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
@@ -32,7 +32,7 @@ jobs:
           dotnet-version: "9.0.x"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: csharp
           queries: security-extended,security-and-quality
@@ -44,6 +44,6 @@ jobs:
           dotnet build JellyfinSecurity.sln --configuration Release --no-restore
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: "/language:csharp"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       attestations: write
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Build fat package in Docker
         run: |

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,12 +22,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
@@ -49,6 +49,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to GitHub code-scanning
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Stale
-        uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
+        uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           days-before-issue-stale: 45
           days-before-issue-close: 14


### PR DESCRIPTION
## Summary

Drains six Dependabot action PRs in one review, and fixes the one of them that cannot pass on its own.

`github/codeql-action/init`, `/analyze` and `/upload-sarif` are three entry points of the same versioned bundle, pinned in two different files. Dependabot opens one PR per entry point, so #155 moved `analyze` to v4.37.3 while `init` stayed on v4.36.2, and CodeQL refused the run:

```
##[error]Loaded a configuration file for version '4.36.2', but running version '4.37.3'
##[error]analyze post-action step failed: Loaded a configuration file for version '4.36.2', but running version '4.37.3'
```

(from the `Analyze (csharp)` job on #155, run 30695789659)

#154 and #155 are individually correct and jointly broken: merging either alone leaves `main` red. They only work as one commit.

Bumped here:

| Action | From | To | Call sites |
|---|---|---|---|
| `github/codeql-action/init` | 4.36.2 | 4.37.3 | `codeql.yml` |
| `github/codeql-action/analyze` | 4.36.2 | 4.37.3 | `codeql.yml` |
| `github/codeql-action/upload-sarif` | 4.36.2 | 4.37.3 | `scorecard.yml` |
| `actions/checkout` | 7.0.0 | 7.0.1 | 5 |
| `ossf/scorecard-action` | 2.4.3 | 2.4.4 | `scorecard.yml` |
| `actions/stale` | 10.3.0 | 11.0.0 | `stale.yml` |
| `oss-fuzz-base/base-builder` | `b3bfcae` | `8b4a73d` | `.clusterfuzzlite/Dockerfile` |

All SHAs are taken verbatim from the corresponding Dependabot PRs.

`actions/stale` v11.0.0 is a major tag but the changelog is an ESM migration plus a transitive `brace-expansion` security override. No input was renamed or removed, and every input `stale.yml` sets (`days-before-*`, `stale-*-label`, `stale-*-message`, `close-*-message`, `exempt-*-labels`, `operations-per-run`, `remove-stale-when-updated`, `ascending`) still exists in v11.

Every action stays pinned by full commit SHA with the version in a trailing comment, so the OSSF Scorecard Pinned-Dependencies check is unaffected.

## Type of change

- [x] CI / build / tests only

## Related issues

Supersedes #150, #151, #152, #153, #154, #155. All six can be closed when this merges.

## How was this tested?

- [ ] Added or updated unit tests
- [ ] Added or updated integration tests
- [ ] Tested manually against a running Jellyfin server
- [x] N/A, explained below

CI-only change with no runtime surface. The proof is CI itself: `Analyze (csharp)` has to go green here, which it cannot do on #155 alone. Locally verified that all five workflow files and `dependabot.yml` still parse as YAML, and that no reference to the old CodeQL SHA (`8aad20d`) or `v4.36.2` survives anywhere under `.github/`.

## Checklist

- [x] My code follows the existing style
- [x] I've added comments only where the *why* isn't obvious from the code
- [ ] I've updated the README / SECURITY.md / docs if behaviour or config changed: n/a
- [x] I've considered backwards compatibility
- [x] I've checked the security implications (SHA pinning preserved throughout)
- [x] CI passes

## Additional notes

The lockstep problem recurs every time CodeQL cuts a release, because nothing in `dependabot.yml` ties the three entry points together. A follow-up PR adds a `codeql-action` group to the github-actions ecosystem so Dependabot bumps them as one PR from now on, alongside the fix for the NuGet lock-file breakage that is currently failing #87, #157, #159 and #162.
