### PR TITLE
deps: bump the three safe packages, with every lock file regenerated

### DIFF
--- a/src/Jellyfin.Plugin.TwoFactorAuth/Jellyfin.Plugin.TwoFactorAuth.csproj
+++ b/src/Jellyfin.Plugin.TwoFactorAuth/Jellyfin.Plugin.TwoFactorAuth.csproj
@@ -56,7 +56,7 @@
          live OIDC sign-in. -->
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.18.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.301">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Jellyfin.Plugin.TwoFactorAuth/packages.lock.json
+++ b/src/Jellyfin.Plugin.TwoFactorAuth/packages.lock.json
@@ -72,9 +72,9 @@
       },
       "Microsoft.CodeAnalysis.NetAnalyzers": {
         "type": "Direct",
-        "requested": "[10.0.301, )",
-        "resolved": "10.0.301",
-        "contentHash": "QAHyooyQN0JB95pI8q/N/eAH7Bb0OWSDSSNFGlmuxC+b/fXUVQJJChOBE6ygJFNkRj42u7rCHCSCPQC5n30tNg=="
+        "requested": "[10.0.302, )",
+        "resolved": "10.0.302",
+        "contentHash": "mbJSf5EOYkgnPQ0jO0qo4AByQYDGbBZDs0+23xdkK2ckuvYJGlPT1nPR0WCSnzwXdiVypOTZ4ArcT4H/X/f1mQ=="
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Direct",

--- a/tests/Jellyfin.Plugin.TwoFactorAuth.Tests/Jellyfin.Plugin.TwoFactorAuth.Tests.csproj
+++ b/tests/Jellyfin.Plugin.TwoFactorAuth.Tests/Jellyfin.Plugin.TwoFactorAuth.Tests.csproj
@@ -23,8 +23,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.17" />
+    <PackageReference Include="NSubstitute" Version="6.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.18" />
     <PackageReference Include="Otp.NET" Version="1.4.1" />
   </ItemGroup>
 

--- a/tests/Jellyfin.Plugin.TwoFactorAuth.Tests/packages.lock.json
+++ b/tests/Jellyfin.Plugin.TwoFactorAuth.Tests/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Microsoft.AspNetCore.TestHost": {
         "type": "Direct",
-        "requested": "[9.0.17, )",
-        "resolved": "9.0.17",
-        "contentHash": "LgEmlWAfPZi31C5lMVs4at7ojcXTp7nXbSdqYnphIunYmX2S6pMKmBxjRcBK1Mcne4rw8PtOI7Ddk8Hg8nGvIQ=="
+        "requested": "[9.0.18, )",
+        "resolved": "9.0.18",
+        "contentHash": "GndaDDMNv9DfvZ3pFDN7d6KkTIDm2Ll+1BQizDrC8ehfzVBGZ8tO4KYXrxQQkwQZjmBjgW54nXEoiJAuCeMLig=="
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
@@ -26,9 +26,9 @@
       },
       "NSubstitute": {
         "type": "Direct",
-        "requested": "[5.3.0, )",
-        "resolved": "5.3.0",
-        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "requested": "[6.1.0, )",
+        "resolved": "6.1.0",
+        "contentHash": "4RKj/p9l0rylPcH+8EXMVbC4yNyfadUdzBFxog2caVThkMQpDw8Q+468mkFMjEmsFt+jXJSdtTwgVNkWzyCsHw==",
         "dependencies": {
           "Castle.Core": "5.1.1"
         }


### PR DESCRIPTION
## Summary

Folds the three green Dependabot NuGet PRs into one commit, and regenerates every affected `packages.lock.json` with `--force-evaluate` instead of by hand.

| Package | From | To | Project |
|---|---|---|---|
| `Microsoft.CodeAnalysis.NetAnalyzers` | 10.0.301 | 10.0.302 | src |
| `Microsoft.AspNetCore.TestHost` | 9.0.17 | 9.0.18 | tests |
| `NSubstitute` | 5.3.0 | 6.1.0 | tests |

`NSubstitute` 6.0.0 is a major release. Its breaking changes are: target frameworks moved to .NET 8 / netstandard2.0, legacy obsolete API removed, `CompatArg` marked obsolete, and nullable annotations enabled on the public API. The test project targets `net9.0` and uses none of the removed API, so the suite compiles and passes unchanged.

Worth noting: `NSubstitute` 6.2.0 shipped on 2026-08-11, after Dependabot opened #163. I kept 6.1.0 here so this is a faithful supersede of the PR that was already reviewable rather than a version nobody has looked at. Happy to move it to 6.2.0 if you'd rather skip a round.

The NetAnalyzers bump only touches the src lock file, because it is declared `PrivateAssets=all` and so never enters the transitive graph the test and fuzz lock files record. That is also why #126 was the one src-side Dependabot PR that went green on its own. See the note at the bottom.

## Type of change

- [x] CI / build / tests only

## Related issues

Supersedes #126, #127, #163.

## How was this tested?

- [x] Added or updated unit tests: existing suite, unchanged
- [ ] Added or updated integration tests
- [ ] Tested manually against a running Jellyfin server
- [ ] N/A

Run locally on the same toolchain CI uses (.NET SDK 9.0.316):

```
dotnet restore JellyfinSecurity.sln --locked-mode
  -> 3/3 projects restored

dotnet build JellyfinSecurity.sln --configuration Release --no-restore
  -> Build succeeded. 0 Warning(s). 0 Error(s).      (TreatWarningsAsErrors=true)

dotnet test JellyfinSecurity.sln --configuration Release --no-restore
  -> Passed! Failed: 0, Passed: 387, Skipped: 0, Total: 387
```

I re-ran the suite on `main` at 78b9f89 to get a baseline: also 387 passed. Same suite, nothing silently dropped by the NSubstitute major.

## Checklist

- [x] My code follows the existing style
- [x] I've added comments only where the *why* isn't obvious from the code
- [ ] I've updated the README / SECURITY.md / docs if behaviour or config changed: n/a
- [x] I've considered backwards compatibility: test-only and analyzer-only, no shipped surface changes
- [x] I've checked the security implications: lock files still pin every transitive package by content hash
- [x] CI passes

## Additional notes

The other four open NuGet PRs (#87, #157, #159, #162) are deliberately **not** in here. Two separate reasons:

1. All four are bumps you pinned on purpose, with the rationale written into the csproj: Jellyfin.Controller/Model at 10.11.9 as the lowest compatible ABI, QuestPDF at 2026.5.0 after the invalid-PDF regression, IdentityModel at 8.18.0 after the OIDC signature-validation break. I've opened a separate issue covering those.

2. Independently of that, all four are red for a mechanical reason that has nothing to do with the packages themselves: `dotnet restore --locked-mode` fails them with `NU1004`, because Dependabot regenerates only `src/.../packages.lock.json` while the test and fuzz lock files record the same packages as `Transitive` through their `ProjectReference`. Any future src-side bump hits this too. A follow-up PR fixes that.
