### PR TITLE
docs(security): give a reporter a next step when both channels are closed

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,21 @@ Use one of the following private channels:
 1. **GitHub Private Vulnerability Reporting** (preferred) - open
    <https://github.com/ZL154/JellyfinSecurity/security/advisories/new>
    and submit the advisory. Only repository maintainers can see it.
-2. **Discord** - DM **`@zack154`** on Discord with a description of the issue.
+2. **Discord** - send a friend request to **`@zack154`** on Discord, then DM
+   the description once it is accepted. Discord drops DMs between people with
+   no mutual server, so the request has to come first.
+
+### If neither channel works
+
+Both paths above can be closed from a reporter's side: private vulnerability
+reporting has to be enabled on the repository before that form accepts
+anything, and a Discord DM waits on a friend request being accepted.
+
+If you hit either wall, **still do not describe the issue in public.** Open a
+normal issue that contains no details at all - no affected endpoint, no
+version range, no reproduction - saying only that you have a security finding
+and asking for a channel. That is enough to start the conversation and gives
+away nothing to anyone reading along.
 
 ### What to include
 


### PR DESCRIPTION
## Summary

`SECURITY.md` lists two private channels, and both can be closed from the reporter's side with nothing documented to do about it. I hit this trying to send you a finding, which is what #168 is about.

**Private vulnerability reporting is not enabled on the repository**, so the preferred link in the policy does not accept anything:

```
POST /repos/ZL154/JellyfinSecurity/security-advisories/reports
403  {"message":"Repository does not have private vulnerability reporting enabled"}
```

**Discord drops DMs between accounts with no mutual server**, and the repo publishes no server invite (checked `README.md`, `SECURITY.md`, `.github/ISSUE_TEMPLATE/config.yml`, `FUNDING.yml`), so that path waits on a friend request being noticed and accepted.

Facing two closed doors, the only move left that a reporter can think of is the exact one the policy opens by forbidding:

> **Please do NOT open a public GitHub issue for security bugs.**

So this documents a third option that keeps that rule intact: a public issue containing **no details at all**, purely to ask for a channel. It gives away nothing to anyone reading along, and it unblocks the conversation instead of leaving a well-intentioned reporter choosing between silence and disclosure.

Also spells out the friend-request step for Discord, which is not obvious unless you have recently tried to DM a stranger there.

## Type of change

- [x] Documentation only

## Related issues

Companion to #168, which asks for the repository setting to be switched on. **This PR does not close that gap on its own**: the real fix is Settings, then Advanced Security (or Code security), then Private vulnerability reporting, then Enable. This only makes sure the next person who hits the same wall has a documented next step in the meantime.

## How was this tested?

- [ ] Added or updated unit tests
- [ ] Added or updated integration tests
- [ ] Tested manually against a running Jellyfin server
- [x] N/A, explained below

Documentation only, no runtime surface. The one factual claim it rests on is the 403 above, which is reproducible against this repository right now by any account.

## Checklist

- [x] My code follows the existing style
- [x] I've added comments only where the *why* isn't obvious from the code
- [x] I've updated the README / SECURITY.md / docs if behaviour or config changed
- [x] I've considered backwards compatibility
- [x] I've checked the security implications: the added guidance is deliberately narrower than a normal issue, and states twice that no detail goes in the public one
- [x] CI passes

## Additional notes

Happy to drop the whole "If neither channel works" section if you would rather just enable PVR and keep the policy short. The section earns its place only while a reporter can reach a dead end, and once the setting is on, the first channel stops being one.