### PR TITLE
fix(2fa): return 403 instead of 500 when Jellyfin refuses the session

### DIFF
--- a/src/Jellyfin.Plugin.TwoFactorAuth/Api/TwoFactorAuthController.cs
+++ b/src/Jellyfin.Plugin.TwoFactorAuth/Api/TwoFactorAuthController.cs
@@ -895,6 +895,20 @@ public class TwoFactorAuthController : ControllerBase
                 // response can't be used as a 2FA-code-validity oracle.
                 return Unauthorized(new { message = "Invalid username, password, or verification code." });
                 }
+                catch (MediaBrowser.Controller.Net.SecurityException ex)
+                {
+                    // Username, password and code were all accepted and Jellyfin then refused
+                    // to open the session on policy grounds: the simultaneous-session cap, or
+                    // the device not being permitted for this user. That is not a credential
+                    // failure, so it must not feed the per-IP ban counter, otherwise a user who
+                    // hits their own session cap bans their own address. The reason text comes
+                    // from Jellyfin so both refusal cases stay accurate.
+                    _logger.LogWarning(
+                        "[2FA] /Authenticate refused for {Name}: {Reason}",
+                        req.Username,
+                        ex.Message);
+                    return StatusCode(StatusCodes.Status403Forbidden, new { message = ex.Message });
+                }
             }
             finally
             {


### PR DESCRIPTION
## Summary

`/TwoFactorAuth/Authenticate` returned a generic 500 when Jellyfin refused to open the session after the password and the 2FA code had both been accepted. This catches `SecurityException` and returns 403 with the reason, which is what the stock `/Users/authenticate` endpoint does for the same condition.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (existing behaviour, config, or API changes)
- [ ] Security fix
- [ ] Documentation only
- [ ] CI / build / tests only
- [ ] Refactor (no functional change)

## Related issues

Fixes #178

## What was happening

`SessionManager.AuthenticateNewSessionInternal` throws `SecurityException` in two cases:

```csharp
throw new SecurityException("User is not allowed access from this device.");
...
throw new SecurityException("User is at their maximum number of sessions.");
```

`AuthenticateWithCode` only caught `AuthenticationException`, so both fell through to the outer `catch (Exception)`, were logged as `[2FA] /Authenticate unhandled exception` with a stack trace, and produced:

```
Internal server error. Check Jellyfin logs for [2FA] entries.
```

That message sends the admin to the `[2FA]` entries, which is the wrong place: the log right above shows the code was accepted, so the 2FA step had already succeeded. On my server it took a while to notice the real blocker was one user sitting at a session cap of 1.

## What this changes

A `catch (MediaBrowser.Controller.Net.SecurityException ex)` clause next to the existing `AuthenticationException` one:

- returns **403**, matching `ExceptionMiddleware.GetStatusCode` in Jellyfin, which maps `SecurityException` to `Status403Forbidden`
- surfaces `ex.Message` rather than hardcoding a reason, so both refusal cases stay accurate. My first draft hardcoded the session-cap wording and would have been wrong for the device case
- logs a single `LogWarning` line instead of an unhandled-exception stack trace, since this is an expected refusal and not a plugin fault
- deliberately does **not** call `_ipBans.RecordFailure`. A policy refusal is not a credential failure, and a user who repeatedly hits their own session cap would otherwise ban their own address

## How was this tested?

- [ ] Added or updated unit tests
- [ ] Added or updated integration tests
- [ ] Tested manually against a running Jellyfin server (state version)
- [x] N/A, explained below

`dotnet build` is clean with 0 warnings and the existing suite is green at **387 passed, 0 failed**.

I did not add a unit test. The failing path needs a live `ISessionManager` that throws mid-call, and the repo has no harness that instantiates `TwoFactorAuthController` (the one controller test that exists calls a static helper). I did not want to invent a contrived seam just to have a test attached. Happy to add one if you would like, and happy to follow whatever shape you prefer.

I reproduced the original bug on a live server, Jellyfin 10.11.11 in Docker with plugin 2.5.21.0, three times in a row with an identical trace. I have **not** deployed a patched build to that server yet, so the fixed behaviour is reasoned from the Jellyfin source rather than observed. Tell me if you want that before merging and I will build it and confirm.

Server the bug was observed on: Jellyfin 10.11.11 in Docker
Clients: Jellyfin Web via the plugin login page

## Checklist

- [x] My code follows the existing style
- [x] I've added comments only where the why isn't obvious from the code
- [ ] I've updated the README / SECURITY.md / docs if behaviour or config changed
- [x] I've considered backwards compatibility
- [x] I've checked the security implications
- [x] CI passes (`dotnet build` + `dotnet test` green)

On docs: no config or documented behaviour changed, only a status code and an error message on an existing endpoint, so I left the docs alone. Say the word if you want a line in the changelog.

On `dotnet format`: the repo does not currently pass `--verify-no-changes`. It flags pre-existing whitespace in `NotificationService.cs`, `OidcService.cs`, and lines 892 to 896 of `TwoFactorAuthController.cs`, which is the existing `AuthenticationException` block right above my change. I left all of it alone to keep this diff to the fix. The lines I added are clean.

## Additional notes

One security point I want to put in front of you rather than decide on my own.

The comment directly above my change is explicit that every auth failure returns an identical message so the response cannot be used as a 2FA-code-validity oracle. Returning 403 here is distinguishable from the 401 that credential failures return, so an attacker who submits valid credentials against a user who happens to be at their cap can tell the credentials were valid.

My reasoning for doing it anyway: the stock `/Users/authenticate` endpoint on the same server already returns 403 for this exact condition and 401 for credential failures, so the distinction is already observable without going through the plugin. Returning 500 here was not protecting anything, it was only making the failure harder to diagnose. If you disagree, I am fine with returning a neutral body and keeping only the status code and the log line, or with keeping 401 entirely. Your call, and I will rework it.
