### PR TITLE
fix(jf12): widen server-side token reads to match #174

### DIFF
--- a/src/Jellyfin.Plugin.TwoFactorAuth/Api/TwoFactorAuthController.cs
+++ b/src/Jellyfin.Plugin.TwoFactorAuth/Api/TwoFactorAuthController.cs
@@ -3564,12 +3564,46 @@ public class TwoFactorAuthController : ControllerBase
     /// ISessionManager.Sessions list (which only holds currently-polling
     /// sessions and shows "no active sessions" for most signed-in browsers).
     /// </summary>
+    /// <summary>[v2.5.22] The caller's Jellyfin access token, taken from
+    /// whichever header the client actually used.
+    ///
+    /// Jellyfin 12 lets an operator switch the legacy <c>X-Emby-Token</c>
+    /// header off, and jellyfin-web moved to
+    /// <c>Authorization: MediaBrowser Token="..."</c> to match. Reading only
+    /// the legacy header therefore breaks silently on such a server, and the
+    /// three call sites below were the ones never widened when
+    /// RequestBlockerMiddleware and SecurityController were:
+    ///
+    ///   - SetPassword/Logout returned 400 "Cannot determine the current
+    ///     Jellyfin session", killing the #134 onboarding logout button.
+    ///   - Setup/QrPair/Begin lost its SEC-H4 ownership cross-check, which is
+    ///     written to fail OPEN when the token is absent - so it degraded
+    ///     silently from "the current device" to "any device you own".
+    ///   - MySessions stopped flagging which row is the current session.
+    ///
+    /// Static and HttpRequest-shaped so the contract is testable without
+    /// standing up the controller.</summary>
+    internal static string? ResolveAccessToken(HttpRequest request)
+    {
+        var token = request.Headers["X-Emby-Token"].FirstOrDefault();
+        if (!string.IsNullOrEmpty(token))
+        {
+            return token;
+        }
+
+        // X-Emby-Authorization carries Client/Device/DeviceId/Version even on
+        // unauthenticated calls, so only a real Token= segment counts.
+        var header = request.Headers["X-Emby-Authorization"].FirstOrDefault()
+            ?? request.Headers["Authorization"].FirstOrDefault();
+        return TwoFactorEnforcementMiddleware.ParseEmbyAuth(header, "Token");
+    }
+
     [HttpGet("MySessions")]
     [Authorize]
     public IActionResult MySessions()
     {
         var userId = GetCurrentUserId();
-        var currentToken = HttpContext.Request.Headers["X-Emby-Token"].FirstOrDefault() ?? string.Empty;
+        var currentToken = ResolveAccessToken(HttpContext.Request) ?? string.Empty;
         var result = _deviceManager.GetDevices(new DeviceQuery { UserId = userId });
         var live = EnumerateSessions()
             .Where(s => s.UserId == userId)
@@ -4960,7 +4994,7 @@ public class TwoFactorAuthController : ControllerBase
         try { userId = GetCurrentUserId(); }
         catch (UnauthorizedAccessException) { return Unauthorized(); }
 
-        var token = HttpContext.Request.Headers["X-Emby-Token"].FirstOrDefault();
+        var token = ResolveAccessToken(HttpContext.Request);
         if (string.IsNullOrWhiteSpace(token))
         {
             return BadRequest(new { message = "Cannot determine the current Jellyfin session." });
@@ -5328,7 +5362,7 @@ public class TwoFactorAuthController : ControllerBase
         // device record for the calling user — without this, a signed-in user
         // could mint a QR token for an arbitrary deviceId and trick someone
         // into approving a device that isn't theirs.
-        var token = HttpContext.Request.Headers["X-Emby-Token"].FirstOrDefault();
+        var token = ResolveAccessToken(HttpContext.Request);
         var devices = _deviceManager.GetDevices(new DeviceQuery { UserId = userId });
         var ownsDevice = devices.Items.Any(d =>
             !string.IsNullOrEmpty(d.DeviceId)

--- a/tests/Jellyfin.Plugin.TwoFactorAuth.Tests/AccessTokenResolutionTests.cs
+++ b/tests/Jellyfin.Plugin.TwoFactorAuth.Tests/AccessTokenResolutionTests.cs
@@ -1,0 +1,103 @@
+using Jellyfin.Plugin.TwoFactorAuth.Api;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Jellyfin.Plugin.TwoFactorAuth.Tests;
+
+/// <summary>
+/// [v2.5.22] Server half of the Jellyfin 12 authorization-header change (#174).
+///
+/// That PR moved the plugin's own pages off the legacy <c>X-Emby-Token</c>
+/// header onto <c>Authorization: MediaBrowser Token="..."</c>, which is
+/// required once an operator disables legacy authorization on Jellyfin 12. Its
+/// tests asserted only that the shipped HTML/JS had changed, so they stayed
+/// green while three server endpoints still read the legacy header alone:
+///
+///   - SetPassword/Logout -> 400, killing the #134 onboarding logout button.
+///   - Setup/QrPair/Begin -> lost its SEC-H4 ownership cross-check, which is
+///     written to fail OPEN when no token is found.
+///   - MySessions -> stopped marking the current session.
+///
+/// These pin the resolver both pages and endpoints now agree on, so the client
+/// and server halves cannot drift apart again silently.
+/// </summary>
+public class AccessTokenResolutionTests
+{
+    private const string Token = "abc123def456";
+
+    private static HttpRequest RequestWith(params (string Name, string Value)[] headers)
+    {
+        var ctx = new DefaultHttpContext();
+        foreach (var (name, value) in headers)
+        {
+            ctx.Request.Headers[name] = value;
+        }
+
+        return ctx.Request;
+    }
+
+    [Fact]
+    public void LegacyEmbyTokenHeader_StillWorks()
+    {
+        // Native clients and older jellyfin-web builds still send this, so the
+        // widening must not become a swap.
+        Assert.Equal(Token, TwoFactorAuthController.ResolveAccessToken(
+            RequestWith(("X-Emby-Token", Token))));
+    }
+
+    [Fact]
+    public void AuthorizationHeader_IsAccepted()
+    {
+        // The Jellyfin 12 shape, and what #174 made the plugin's pages send.
+        // Before this change every endpoint below returned null here.
+        Assert.Equal(Token, TwoFactorAuthController.ResolveAccessToken(
+            RequestWith(("Authorization", $"MediaBrowser Token=\"{Token}\""))));
+    }
+
+    [Fact]
+    public void XEmbyAuthorizationHeader_IsAccepted()
+    {
+        Assert.Equal(Token, TwoFactorAuthController.ResolveAccessToken(
+            RequestWith(("X-Emby-Authorization", $"MediaBrowser Token=\"{Token}\""))));
+    }
+
+    [Fact]
+    public void FullClientAuthorizationHeader_YieldsOnlyTheToken()
+    {
+        // The real header jellyfin-web sends carries four other fields; the
+        // resolver must pick Token= and not, say, DeviceId=.
+        var header = "MediaBrowser Client=\"Jellyfin Web\", Device=\"Firefox\", "
+            + $"DeviceId=\"dev-999\", Version=\"10.11.11\", Token=\"{Token}\"";
+
+        Assert.Equal(Token, TwoFactorAuthController.ResolveAccessToken(
+            RequestWith(("Authorization", header))));
+    }
+
+    [Fact]
+    public void LegacyHeaderWins_WhenBothArePresent()
+    {
+        // Not a preference so much as a guarantee of no behaviour change for
+        // any client that still sends the legacy header.
+        Assert.Equal(Token, TwoFactorAuthController.ResolveAccessToken(
+            RequestWith(
+                ("X-Emby-Token", Token),
+                ("Authorization", "MediaBrowser Token=\"a-different-token\""))));
+    }
+
+    [Fact]
+    public void UnauthenticatedClientMetadata_YieldsNoToken()
+    {
+        // X-Emby-Authorization is present on anonymous calls too, carrying
+        // Client/Device/DeviceId/Version but no Token. Returning DeviceId here
+        // would hand QrPairBegin a bogus value to compare against.
+        Assert.Null(TwoFactorAuthController.ResolveAccessToken(
+            RequestWith(("X-Emby-Authorization",
+                "MediaBrowser Client=\"Jellyfin Web\", Device=\"Firefox\", DeviceId=\"dev-999\", Version=\"10.11.11\""))));
+    }
+
+    [Fact]
+    public void NoHeadersAtAll_YieldsNull()
+    {
+        Assert.Null(TwoFactorAuthController.ResolveAccessToken(RequestWith()));
+    }
+}


### PR DESCRIPTION
Follow-up to #174, which is the client half of the Jellyfin 12 authorization-header change.

#174 moved the plugin's own pages from `X-Emby-Token` to `Authorization: MediaBrowser Token="..."`, which is required once an operator disables legacy authorization on Jellyfin 12. That change is correct. But three server endpoints still read `X-Emby-Token` alone, and #174's tests only assert that the shipped HTML/JS changed — they never exercise a server round-trip. So the suite stayed green over three real breaks:

| Endpoint | Effect on a server with legacy auth off |
|---|---|
| `SetPassword/Logout` | `400 "Cannot determine the current Jellyfin session"` — the #134 onboarding logout button stops working |
| `Setup/QrPair/Begin` | Loses its SEC-H4 ownership cross-check. That check is written `(string.IsNullOrEmpty(token) \|\| d.AccessToken == token)`, so with no token found it **fails open**, degrading from "the current device" to "any device you own" |
| `MySessions` | Stops flagging which row is the current session |

`RequestBlockerMiddleware.GetAccessToken` and `SecurityController` already resolved this correctly; these three call sites were simply never widened. This adds `TwoFactorAuthController.ResolveAccessToken` with the same fallback order (`X-Emby-Token`, then a `Token=` segment in `X-Emby-Authorization` / `Authorization`) and points all three at it.

Legacy header still wins when both are present, so nothing changes for native clients that still send it.

## Testing

7 new tests pinning the resolver contract, so the client and server halves cannot drift apart silently again. Mutation-checked: reverting the fallback turns 3 of them red.

435/435 locally on this branch, `dotnet restore --locked-mode` clean.

Thanks @martin-77 — the client change was the right call, this just carries it through to the server side.